### PR TITLE
Component bounds and CompleteStable bug fixes

### DIFF
--- a/Barrister.cpp
+++ b/Barrister.cpp
@@ -405,14 +405,16 @@ LifeState SearchState::ForcedInactiveCells(
   }
 
   if (params->componentActiveBounds.first != -1) {
+    LifeState tempResult = ~LifeState();
     for (auto &c : active.Components()) {
       auto wh = c.WidthHeight();
 
       if (wh.first > params->componentActiveBounds.first || wh.second > params->componentActiveBounds.second)
         return ~LifeState();
 
-      result |= ~active.BufferAround(params->componentActiveBounds) & c.BigZOI();
+      tempResult &= ~c.BufferAround(params->componentActiveBounds);
     }
+    result |= tempResult;
   }
 
   if (params->maxEverActiveCells != -1 &&
@@ -435,14 +437,15 @@ LifeState SearchState::ForcedInactiveCells(
   }
 
   if (params->componentEverActiveBounds.first != -1) {
+    LifeState tempResult = ~LifeState();
     for (auto &c : everActive.Components()) {
       auto wh = c.WidthHeight();
 
       if (wh.first > params->componentEverActiveBounds.first || wh.second > params->componentEverActiveBounds.second)
         return ~LifeState();
-
-      result |= ~everActive.BufferAround(params->componentEverActiveBounds) & c.BigZOI();
+      tempResult &= ~c.BufferAround(params->componentEverActiveBounds);
     }
+    result |= tempResult;
   }
 
   if (params->hasStator)

--- a/LifeStableState.hpp
+++ b/LifeStableState.hpp
@@ -691,7 +691,7 @@ LifeState LifeStableState::CompleteStable(unsigned timeout, bool minimise) {
   auto startTime = std::chrono::system_clock::now();
   auto timeLimit = startTime + std::chrono::seconds(timeout);
 
-  while(!(unknownStable & ~searchArea).IsEmpty()) {
+  do {
     searchArea = searchArea.ZOI();
     LifeStableState copy = *this;
     copy.unknownStable &= searchArea;
@@ -700,7 +700,7 @@ LifeState LifeStableState::CompleteStable(unsigned timeout, bool minimise) {
     auto currentTime = std::chrono::system_clock::now();
     if (best.GetPop() > 0 || currentTime > timeLimit)
       break;
-  }
+  } while(!(unknownStable & ~searchArea).IsEmpty());
   return best;
 }
 


### PR DESCRIPTION
Fixed two bugs: first, CompleteStable returned an empty LifeState if the state was already complete. Second, forced inactive cells from component bounds.